### PR TITLE
chargebee: use the custom http client for requests

### DIFF
--- a/http_request.go
+++ b/http_request.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 )
 
-//Do is used to execute an API Request.
+// Do is used to execute an API Request.
 func Do(req *http.Request) (string, error) {
-
-	client := &http.Client{
-		Timeout: TotalHTTPTimeout,
+	var client *http.Client
+	if httpClient != nil {
+		client = httpClient
+	} else {
+		client = &http.Client{Timeout: TotalHTTPTimeout}
 	}
 
 	response, err := client.Do(req)
@@ -45,7 +47,6 @@ func ErrorHandling(resBody []byte) error {
 	}
 	if cbErr.APIErrorCode == "" {
 		return errors.New("the api_error_code is not present - probably not a chargebee error")
-
 	}
 	switch cbErr.Type {
 


### PR DESCRIPTION
Get the http client if it has been configured with the chargeebee.WithHttpClient option to do the requests